### PR TITLE
Increase timeout.

### DIFF
--- a/jenkins/config.groovy
+++ b/jenkins/config.groovy
@@ -3,7 +3,7 @@
 class config {
 
   // Wait timeout in minutes
-  public static final int WAIT_TIMEOUT = 10
+  public static final int WAIT_TIMEOUT = 20
 
   // Deployment configuration
   public static final String[] DEPLOYMENT_ENVIRONMENT_TAGS = ['dev', 'test', 'prod']


### PR DESCRIPTION
- Make sure the build/deploy has more time to complete when there is network slowness.

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>